### PR TITLE
使用localhost:6379链接时，出现异常

### DIFF
--- a/src/FreeRedis/Internal/DefaultRedisSocket.cs
+++ b/src/FreeRedis/Internal/DefaultRedisSocket.cs
@@ -182,10 +182,10 @@ namespace FreeRedis.Internal
             {
                 ResetHost(Host);
 
-                IPEndPoint endpoint = IPAddress.TryParse(_ip, out var tryip) ?
-                    new IPEndPoint(tryip, _port) :
-                    new IPEndPoint(Dns.GetHostAddresses(_ip).FirstOrDefault() ?? IPAddress.Parse(_ip), _port);
-                var localSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                EndPoint endpoint = ParseEndPoint(_ip, _port);
+                var localSocket = endpoint.AddressFamily == AddressFamily.InterNetworkV6 ? 
+                    new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp):
+                    new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
                 var asyncResult = localSocket.BeginConnect(endpoint, null, null);
                 if (!asyncResult.AsyncWaitHandle.WaitOne(ConnectTimeout, true))
@@ -267,6 +267,21 @@ namespace FreeRedis.Internal
             }
 
             return new KeyValuePair<string, int>(host, 6379);
+        }
+
+        private static EndPoint ParseEndPoint(string ip, int port)
+        {
+            if (IPAddress.TryParse(ip, out var tryip))
+            {
+                return new IPEndPoint(tryip, port);
+            }
+
+            if (Dns.GetHostAddresses(ip).Length == 0)
+            {
+                throw new Exception($"无法解析“{ip}”");
+            }
+
+            return new DnsEndPoint(ip, port);
         }
     }
 }


### PR DESCRIPTION
会出现:“【localhost:6379/0】This protocol version is not supported.”的异常；
在转换EndPoint时，使用DNS解析的ip可能是ipv6的，我的localhost会解析成[::1]:6379,导致后面的ipv4的Socket链接失败