### PR TITLE
fix the exception which says 'The client ID you want redirect to does…

### DIFF
--- a/examples/console_netcore31_client_side_caching/Program.cs
+++ b/examples/console_netcore31_client_side_caching/Program.cs
@@ -15,7 +15,7 @@ namespace console_netcore31_client_side_caching
         {
             //var r = new RedisClient("127.0.0.1:6379", false); //redis 3.2 Single test
             //var r = new RedisClient("127.0.0.1:6379,database=1,min pool size=500,max pool size=500"); //redis 3.2
-            var r = new RedisClient("127.0.0.1:6379,database=1", "127.0.0.1:6379,database=1");
+            var r = new RedisClient("127.0.0.1:6379,database=10", "127.0.0.1:6380,database=10", "127.0.0.1:6381,database=10");
             //var r = new RedisClient(new [] { (ConnectionStringBuilder)"192.168.164.10:6379,database=1", (ConnectionStringBuilder)"192.168.164.10:6379,database=2" }); //redis 6.0
             r.Serialize = obj => JsonConvert.SerializeObject(obj);
             r.Deserialize = (json, type) => JsonConvert.DeserializeObject(json, type);
@@ -72,7 +72,7 @@ namespace console_netcore31_client_side_caching
             var val0112 = cli.Get<TestClass>("Interceptor011"); //本地
             var val0113 = cli.Get<TestClass>("Interceptor011"); //断点等3秒，redis-server
 
-
+            Console.WriteLine("all test has done running");
             Console.ReadKey();
 
             cli.Dispose();

--- a/src/FreeRedis/ClientSideCaching.cs
+++ b/src/FreeRedis/ClientSideCaching.cs
@@ -99,7 +99,7 @@ namespace FreeRedis
             {
                 var poolkey = pool.Key;
                 //return _sub.RedisSocket.ClientId;
-                if (_cli.Adapter.UseType != RedisClient.UseType.Cluster) return _sub.RedisSocket.ClientId;
+                if (_cli.Adapter.UseType != RedisClient.UseType.Cluster && _sub.RedisSocket.Host == host) return _sub.RedisSocket.ClientId;
 
                 ClusterTrackingInfo tracking = null;
                 lock (_clusterTrackingsLock)


### PR DESCRIPTION
#81 

Error log
```
127.0.0.1:6379/0      > SELECT 10
OK
(18ms)

127.0.0.1:6379/0      > CLIENT ID
34
(1ms)

127.0.0.1:6379        > Connected, ClientId: 34, Database: 10, Pool: 0/1
127.0.0.1:6379/10     > PING
PONG
(116ms)

127.0.0.1:6379/10     > PING
PONG
(1ms)

127.0.0.1:6379/10     > SUBSCRIBE __redis__:invalidate

(8ms)

127.0.0.1:6379/0      > SELECT 10
OK
(3ms)

127.0.0.1:6379/0      > CLIENT ID
35
(0ms)

127.0.0.1:6379/10     > CLIENT TRACKING ON REDIRECT 34
FreeRedis.RedisResult
(7ms)

127.0.0.1:6379        > Connected, ClientId: 35, Database: 10, Pool: 0/2
127.0.0.1:6379/10     > PING
PONG
(15ms)

127.0.0.1:6379/10     > SET Interceptor01 123123
OK
(30ms)

127.0.0.1:6380/0      > SELECT 10
OK
(2ms)

127.0.0.1:6380/0      > CLIENT ID
29
(0ms)

127.0.0.1:6380/10     > CLIENT TRACKING ON REDIRECT 34
ERR The client ID you want redirect to does not exist
(116ms)

Not connected         > PING
ERR The client ID you want redirect to does not exist
(152ms)

127.0.0.1:6380/0      > SELECT 10
OK
(1ms)

127.0.0.1:6380/0      > CLIENT ID
30
(0ms)

127.0.0.1:6380/10     > CLIENT TRACKING ON REDIRECT 34
ERR The client ID you want redirect to does not exist
(77ms)

Not connected         > PING
ERR The client ID you want redirect to does not exist
(114ms)

127.0.0.1:6380        > Unavailable
Unhandled exception. 【127.0.0.1:6380/10】Next recovery time：2022/10/11 10:54:23
System.Exception: 【127.0.0.1:6380/10】状态不可用，等待后台检查程序恢复方可使用。ERR The client ID you want redirect to does not exist
 ---> FreeRedis.RedisServerException: ERR The client ID you want redirect to does not exist
   at FreeRedis.RedisResult.ThrowOrNothing() in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\RespHelper.cs:line 944
   at FreeRedis.RedisClient.<>c.<ClientTracking>b__70_2(RedisResult rt) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Connection.cs:line 69
   at FreeRedis.RedisClient.SingleInsideAdapter.<>c__DisplayClass5_0`1.<AdapterCall>b__0() in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\SingleInsideAdapter.cs:line 47
   at FreeRedis.RedisClient.LogCall[T](CommandPacket cmd, Func`1 func) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient.cs:line 113
   at FreeRedis.RedisClient.SingleInsideAdapter.AdapterCall[TValue](CommandPacket cmd, Func`2 parse) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\SingleInsideAdapter.cs:line 42
   at FreeRedis.RedisClient.Call[TValue](CommandPacket cmd, Func`2 parse) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient.cs:line 84
   at FreeRedis.RedisClient.ClientTracking(Boolean on_off, Nullable`1 redirect, String[] prefix, Boolean bcast, Boolean optin, Boolean optout, Boolean noloop) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Connection.cs:line 60
   at FreeRedis.ClientSideCachingExtensions.ClientSideCachingContext.<Start>b__7_2(Object _, ConnectedEventArgs e) in D:\GithubWork\FreeRedis\src\FreeRedis\ClientSideCaching.cs:line 73
   at FreeRedis.RedisClient.OnConnected(RedisClient cli, ConnectedEventArgs e) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient.cs:line 142
   at FreeRedis.Internal.RedisClientPool.<>c__DisplayClass0_0.<.ctor>b__0(Object s, EventArgs o) in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\RedisClientPool.cs:line 115
   at FreeRedis.Internal.RedisClientPoolPolicy.<OnCreate>b__40_0(RedisClient cli) in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\RedisClientPool.cs:line 169
   at FreeRedis.RedisClient.SingleInsideAdapter.<>c__DisplayClass1_0.<.ctor>b__0(Object s, EventArgs e) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\SingleInsideAdapter.cs:line 22
   at FreeRedis.Internal.DefaultRedisSocket.Connect() in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\DefaultRedisSocket.cs:line 254
   at FreeRedis.Internal.DefaultRedisSocket.Write(CommandPacket cmd) in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\DefaultRedisSocket.cs:line 159
   at FreeRedis.RedisClient.SingleInsideAdapter.<>c__DisplayClass5_0`1.<AdapterCall>b__0() in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\SingleInsideAdapter.cs:line 44
   at FreeRedis.RedisClient.LogCall[T](CommandPacket cmd, Func`1 func) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient.cs:line 113
   at FreeRedis.RedisClient.SingleInsideAdapter.AdapterCall[TValue](CommandPacket cmd, Func`2 parse) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\SingleInsideAdapter.cs:line 42
   at FreeRedis.RedisClient.Call[TValue](CommandPacket cmd, Func`2 parse) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient.cs:line 84
   at FreeRedis.RedisClient.Ping(String message) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Connection.cs:line 94
   at FreeRedis.Internal.RedisClientPoolPolicy.PrevReheatConnectionPool(ObjectPool`1 pool, Int32 minPoolSize) in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\RedisClientPool.cs:line 228
   --- End of inner exception stack trace ---
   at FreeRedis.Internal.ObjectPool.ObjectPool`1.GetFree(Boolean checkAvailable) in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\ObjectPool\ObjectPool.cs:line 266
   at FreeRedis.Internal.ObjectPool.ObjectPool`1.Get(Nullable`1 timeout) in D:\GithubWork\FreeRedis\src\FreeRedis\Internal\ObjectPool\ObjectPool.cs:line 295
   at FreeRedis.RedisClient.PoolingAdapter.GetRedisSocket(CommandPacket cmd) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\PoolingAdapter.cs:line 61
   at FreeRedis.RedisClient.PoolingAdapter.<>c__DisplayClass9_0`1.<AdapterCall>b__0() in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\PoolingAdapter.cs:line 74
   at FreeRedis.RedisClient.LogCall[T](CommandPacket cmd, Func`1 func) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient.cs:line 113
   at FreeRedis.RedisClient.PoolingAdapter.AdapterCall[TValue](CommandPacket cmd, Func`2 parse) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Adapter\PoolingAdapter.cs:line 70
   at FreeRedis.RedisClient.Call[TValue](CommandPacket cmd, Func`2 parse) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient.cs:line 84
   at FreeRedis.RedisClient.Get(String key) in D:\GithubWork\FreeRedis\src\FreeRedis\RedisClient\Strings.cs:line 763
   at console_netcore31_client_side_caching.Program.Main(String[] args) in D:\GithubWork\FreeRedis\examples\console_netcore31_client_side_caching\Program.cs:line 46
```   