### PR TITLE
fix: ConnectionStringBuilder的Host参数兼容localhost&Module提供异步方法

### DIFF
--- a/src/FreeRedis/ConnectionStringBuilder.cs
+++ b/src/FreeRedis/ConnectionStringBuilder.cs
@@ -13,7 +13,7 @@ namespace FreeRedis
         public string Host
         {
             get => string.IsNullOrWhiteSpace(_Host) ? "127.0.0.1:6379" : _Host;
-            set => _Host = string.IsNullOrWhiteSpace(value) ? "127.0.0.1:6379" : value;
+            set => _Host = string.IsNullOrWhiteSpace(value) ? "127.0.0.1:6379" : value.StartsWith("localhost",StringComparison.OrdinalIgnoreCase) ? Regex.Replace(value,"localhost","127.0.0.1", RegexOptions.IgnoreCase) : value;
         }
         public bool Ssl { get; set; } = false;
         public RedisProtocol Protocol { get; set; } = RedisProtocol.RESP2;

--- a/src/FreeRedis/RedisClient/Modules/BloomFilter.cs
+++ b/src/FreeRedis/RedisClient/Modules/BloomFilter.cs
@@ -2,11 +2,43 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FreeRedis
 {
     partial class RedisClient
     {
+#if isasync
+        #region async (copy from sync)
+
+        public Task<string> BfReserveAsync(string key, decimal errorRate, long capacity, int expansion = 2, bool nonScaling = false) => CallAsync("BF.RESERVE"
+            .InputKey(key)
+            .Input(errorRate, capacity)
+            .InputIf(expansion != 2, "EXPANSION", expansion)
+            .InputIf(nonScaling, "NONSCALING"), rt => rt.ThrowOrValue<string>());
+        public Task<bool> BfAddAsync(string key, string item) => CallAsync("BF.ADD".InputKey(key, item), rt => rt.ThrowOrValue<bool>());
+        public Task<bool[]> BfMAddAsync(string key, string[] items) => CallAsync("BF.MADD".InputKey(key, items), rt => rt.ThrowOrValue<bool[]>());
+
+        public Task<string> BfInsertAsync(string key, string[] items, long? capacity = null, string error = null, int expansion = 2, bool noCreate = false, bool nonScaling = false) => CallAsync("BF.INSERT"
+            .InputKey(key)
+            .InputIf(capacity != null, "CAPACITY", capacity)
+            .InputIf(!string.IsNullOrWhiteSpace(error), "ERROR", error)
+            .InputIf(expansion != 2, "EXPANSION", expansion)
+            .InputIf(noCreate, "NOCREATE")
+            .InputIf(nonScaling, "NONSCALING")
+            .Input("ITEMS", items), rt => rt.ThrowOrValue<string>());
+
+        public Task<bool> BfExistsAsync(string key, string item) => CallAsync("BF.EXISTS".InputKey(key, item), rt => rt.ThrowOrValue<bool>());
+        public Task<bool[]> BfMExistsAsync(string key, string[] items) => CallAsync("BF.MEXISTS".InputKey(key, items), rt => rt.ThrowOrValue<bool[]>());
+        public Task<ScanResult<byte[]>> BfScanDumpAsync(string key, long iter) => CallAsync("BF.SCANDUMP".InputKey(key, iter), rt => rt.ThrowOrValue((a, _) =>
+            new ScanResult<byte[]>(a[0].ConvertTo<long>(), a[1].ConvertTo<byte[][]>())));
+
+        public Task<string> BfLoadChunkAsync(string key, long iter, byte[] data) => CallAsync("BF.LOADCHUNK".InputKey(key, iter).InputRaw(data), rt => rt.ThrowOrValue<string>());
+        public Task<Dictionary<string, string>> BfInfoAsync(string key) => CallAsync("BF.INFO".InputKey(key), rt => rt.ThrowOrValue((a, _) => a.MapToHash<string>(rt.Encoding)));
+
+        #endregion
+#endif
+
         public string BfReserve(string key, decimal errorRate, long capacity, int expansion = 2, bool nonScaling = false) => Call("BF.RESERVE"
             .InputKey(key)
             .Input(errorRate, capacity)

--- a/src/FreeRedis/RedisClient/Modules/RedisBloomCountMinSketch.cs
+++ b/src/FreeRedis/RedisClient/Modules/RedisBloomCountMinSketch.cs
@@ -2,11 +2,32 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FreeRedis
 {
     partial class RedisClient
     {
+#if isasync
+        #region async (copy from sync)
+
+        public Task<string> CmsInitByDimAsync(string key, long width, long depth) => CallAsync("CMS.INITBYDIM".InputKey(key, width, depth), rt => rt.ThrowOrValue<string>());
+        public Task<string> CmsInitByProbAsync(string key, decimal error, decimal probability) => CallAsync("CMS.INITBYPROB".InputKey(key, error, probability), rt => rt.ThrowOrValue<string>());
+
+        public Task<long> CmsIncrByAsync(string key, string item, long increment) => CallAsync("CMS.INCRBY".InputKey(key, item, increment), rt => rt.ThrowOrValue(a => a.ConvertTo<long[]>().FirstOrDefault()));
+        public Task<long[]> CmsIncrByAsync(string key, Dictionary<string, long> itemIncrements) => CallAsync("CMS.INCRBY".InputKey(key).InputKv(itemIncrements, false, SerializeRedisValue), rt => rt.ThrowOrValue<long[]>());
+
+        public Task<long[]> CmsQueryAsync(string key, string[] items) => CallAsync("CMS.QUERY".InputKey(key, items), rt => rt.ThrowOrValue<long[]>());
+        public Task<string> CmsMergeAsync(string dest, long numKeys, string[] src, long[] weights) => CallAsync("CMS.MERGE"
+            .InputKey(dest, numKeys)
+            .InputKey(src)
+            .InputIf(weights?.Any() == true, "WEIGHTS", weights), rt => rt.ThrowOrValue<string>());
+
+        public Task<Dictionary<string, string>> CmsInfoAsync(string key) => CallAsync("CMS.INFO".InputKey(key), rt => rt.ThrowOrValue((a, _) => a.MapToHash<string>(rt.Encoding)));
+
+        #endregion
+#endif
+
         public string CmsInitByDim(string key, long width, long depth) => Call("CMS.INITBYDIM".InputKey(key, width, depth), rt => rt.ThrowOrValue<string>());
         public string CmsInitByProb(string key, decimal error, decimal probability) => Call("CMS.INITBYPROB".InputKey(key, error, probability), rt => rt.ThrowOrValue<string>());
 

--- a/src/FreeRedis/RedisClient/Modules/RedisBloomCuckooFilter.cs
+++ b/src/FreeRedis/RedisClient/Modules/RedisBloomCuckooFilter.cs
@@ -2,11 +2,46 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FreeRedis
 {
     partial class RedisClient
     {
+#if isasync
+        #region async (copy from sync)
+
+        public Task<string> CfReserveAsync(string key, long capacity, long? bucketSize = null, long? maxIterations = null, int? expansion = null) => CallAsync("CF.RESERVE"
+            .InputKey(key, capacity)
+            .InputIf(bucketSize != 2, "BUCKETSIZE", bucketSize)
+            .InputIf(maxIterations != 2, "MAXITERATIONS", maxIterations)
+            .InputIf(expansion != 2, "EXPANSION", expansion), rt => rt.ThrowOrValue<string>());
+
+        public Task<bool> CfAddAsync(string key, string item) => CallAsync("CF.ADD".InputKey(key, item), rt => rt.ThrowOrValue<bool>());
+        public Task<bool> CfAddNxAsync(string key, string item) => CallAsync("CF.ADDNX".InputKey(key, item), rt => rt.ThrowOrValue<bool>());
+
+        async public Task<string> CfInsertAsync(string key, string[] items, long? capacity = null, bool noCreate = false) => await CfInsertAsync(false, key, items, capacity, noCreate);
+        async public Task<string> CfInsertNxAsync(string key, string[] items, long? capacity = null, bool noCreate = false) => await CfInsertAsync(true, key, items, capacity, noCreate);
+        Task<string> CfInsertAsync(bool nx, string key, string[] items, long? capacity = null, bool noCreate = false) => CallAsync((nx ? "CF.INSERTNX" : "CF.INSERT")
+            .InputKey(key)
+            .InputIf(capacity != null, "CAPACITY", capacity)
+            .InputIf(noCreate, "NOCREATE")
+            .Input("ITEMS", items), rt => rt.ThrowOrValue<string>());
+
+        public Task<bool> CfExistsAsync(string key, string item) => CallAsync("CF.EXISTS".InputKey(key, item), rt => rt.ThrowOrValue<bool>());
+        public Task<bool> CfDelAsync(string key, string item) => CallAsync("CF.DEL".InputKey(key, item), rt => rt.ThrowOrValue<bool>());
+
+        public Task<long> CfCountAsync(string key, string item) => CallAsync("CF.COUNT".InputKey(key, item), rt => rt.ThrowOrValue<long>());
+
+        public Task<ScanResult<byte[]>> CfScanDumpAsync(string key, long iter) => CallAsync("CF.SCANDUMP".InputKey(key, iter), rt => rt.ThrowOrValue((a, _) =>
+            new ScanResult<byte[]>(a[0].ConvertTo<long>(), a[1].ConvertTo<byte[][]>())));
+
+        public Task<string> CfLoadChunkAsync(string key, long iter, byte[] data) => CallAsync("CF.LOADCHUNK".InputKey(key, iter).InputRaw(data), rt => rt.ThrowOrValue<string>());
+        public Task<Dictionary<string, string>> CfInfoAsync(string key) => CallAsync("CF.INFO".InputKey(key), rt => rt.ThrowOrValue((a, _) => a.MapToHash<string>(rt.Encoding)));
+
+        #endregion
+#endif
+
         public string CfReserve(string key, long capacity, long? bucketSize = null, long? maxIterations = null, int? expansion = null) => Call("CF.RESERVE"
             .InputKey(key, capacity)
             .InputIf(bucketSize != 2, "BUCKETSIZE", bucketSize)

--- a/src/FreeRedis/RedisClient/Modules/RedisBloomTopKFilter.cs
+++ b/src/FreeRedis/RedisClient/Modules/RedisBloomTopKFilter.cs
@@ -2,11 +2,30 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace FreeRedis
 {
     partial class RedisClient
     {
+#if isasync
+        #region async (copy from sync)
+
+        public Task<string> TopkReserveAsync(string key, long topk, long width, long depth, decimal decay) => CallAsync("TOPK.RESERVE".InputKey(key).Input(topk, width, depth, decay), rt => rt.ThrowOrValue<string>());
+        public Task<string[]> TopkAddAsync(string key, string[] items) => CallAsync("TOPK.ADD".InputKey(key, items), rt => rt.ThrowOrValue<string[]>());
+
+        public Task<string> TopkIncrByAsync(string key, string item, long increment) => CallAsync("TOPK.INCRBY".InputKey(key, item, increment), rt => rt.ThrowOrValue((a, _) => a.FirstOrDefault().ConvertTo<string>()));
+        public Task<string[]> TopkIncrByAsync(string key, Dictionary<string, long> itemIncrements) => CallAsync("TOPK.INCRBY".InputKey(key).InputKv(itemIncrements, false, SerializeRedisValue), rt => rt.ThrowOrValue<string[]>());
+
+        public Task<bool[]> TopkQueryAsync(string key, string[] items) => CallAsync("TOPK.QUERY".InputKey(key, items), rt => rt.ThrowOrValue<bool[]>());
+        public Task<long[]> TopkCountAsync(string key, string[] items) => CallAsync("TOPK.COUNT".InputKey(key, items), rt => rt.ThrowOrValue<long[]>());
+
+        public Task<string[]> TopkListAsync(string key) => CallAsync("TOPK.LIST".InputKey(key), rt => rt.ThrowOrValue<string[]>());
+        public Task<Dictionary<string, string>> TopkInfoAsync(string key) => CallAsync("TOPK.INFO".InputKey(key), rt => rt.ThrowOrValue((a, _) => a.MapToHash<string>(rt.Encoding)));
+
+        #endregion
+#endif
+
         public string TopkReserve(string key, long topk, long width, long depth, decimal decay) => Call("TOPK.RESERVE".InputKey(key).Input(topk, width, depth, decay), rt => rt.ThrowOrValue<string>());
         public string[] TopkAdd(string key, string[] items) => Call("TOPK.ADD".InputKey(key, items), rt => rt.ThrowOrValue<string[]>());
 

--- a/src/FreeRedis/RedisClient/Modules/RedisJson.cs
+++ b/src/FreeRedis/RedisClient/Modules/RedisJson.cs
@@ -8,6 +8,56 @@ namespace FreeRedis
 {
     partial class RedisClient
     {
+#if isasync
+        #region async (copy from sync)
+
+        public Task<string> JsonGetAsync(string key, string indent = default, string newline = default, string space = default, params string[] paths)
+            => CallAsync("JSON.GET".InputKey(key)
+                .InputIf(indent != null, "INDENT", indent)
+                .InputIf(newline != null, "NEWLINE", newline)
+                .InputIf(space != null, "SPACE", space)
+                .Input(paths), rt => rt.ThrowOrValue<string>());
+
+        public Task<string[]> JsonMGetAsync(string[] keys, string path = "$") => CallAsync("JSON.MGET".InputKey(keys).Input(path), rt => rt.ThrowOrValue<string[]>());
+
+        public Task<bool> JsonSetAsync(string key, string value, string path = "$", bool nx = false, bool xx = false)
+        {
+            return CallAsync("JSON.SET".InputKey(key, path)
+                .InputRaw(value)
+                .InputIf(nx, "NX")
+                .InputIf(xx, "XX"), rt => rt.ThrowOrValue<string>() == "OK");
+        }
+
+        public Task<long> JsonDelAsync(string key, string path = "$") => CallAsync("JSON.DEL".InputKey(key, path), rt => rt.ThrowOrValue<long>());
+
+        public Task<long[]> JsonArrInsertAsync(string key, string path, long index = 0, params object[] values) => CallAsync("JSON.ARRINSERT".InputKey(key, path, index).Input(values.Select(SerializeRedisValue).ToArray()), rt => rt.ThrowOrValue<long[]>());
+
+        public Task<long[]> JsonArrAppendAsync(string key, string path, params object[] values) => CallAsync("JSON.ARRAPPEND".InputKey(key, path).Input(values.Select(SerializeRedisValue).ToArray()), rt => rt.ThrowOrValue<long[]>());
+
+        public Task<long[]> JsonArrIndexAsync<T>(string key, string path, T value) where T : struct => CallAsync("JSON.ARRINDEX".InputKey(key, path).InputRaw(SerializeRedisValue(value)), rt => rt.ThrowOrValue<long[]>());
+
+        public Task<long[]> JsonArrLenAsync(string key, string path) => CallAsync("JSON.ARRLEN".InputKey(key, path), rt => rt.ThrowOrValue<long[]>());
+
+        async public Task<object[]> JsonArrPopAsync(string key, string path, int index = -1) => await HReadArrayAsync<object>("JSON.ARRPOP".InputKey(key, path, index));
+
+        public Task<long[]> JsonArrTrimAsync(string key, string path, int start, int stop) => CallAsync("JSON.ARRTRIM".InputKey(key, path).Input(start, stop), rt => rt.ThrowOrValue<long[]>());
+        public Task<long[]> JsonClearAsync(string key, string path = "$") => CallAsync("JSON.CLEAR".InputKey(key, path), rt => rt.ThrowOrValue<long[]>());
+        public Task<long[]> JsonDebugMemoryAsync(string key, string path = "$") => CallAsync("JSON.DEBUG".InputKey("MEMORY", key, path), rt => rt.ThrowOrValue<long[]>());
+
+        public Task<long> JsonForgetAsync(string key, string path = "$") => CallAsync("JSON.FORGET".InputKey(key, path), rt => rt.ThrowOrValue<long>());
+        public Task<string> JsonNumIncrByAsync(string key, string path, double value) => CallAsync("JSON.NUMINCRBY".InputKey(key, path).Input(value), rt => rt.ThrowOrValue<string>());
+        public Task<string> JsonNumMultByAsync(string key, string path, double value) => CallAsync("JSON.NUMMULTBY".InputKey(key, path).Input(value), rt => rt.ThrowOrValue<string>());
+
+        public Task<string[][]> JsonObjKeysAsync(string key, string path = "$") => CallAsync("JSON.OBJKEYS".InputKey(key, path), rt => rt.ThrowOrValue<string[][]>());
+        public Task<long[]> JsonObjLenAsync(string key, string path = "$") => CallAsync("JSON.OBJLEN".InputKey(key, path), rt => rt.ThrowOrValue<long[]>());
+        public Task<object[][]> JsonRespAsync(string key, string path = "$") => CallAsync("JSON.RESP".InputKey(key, path), rt => rt.ThrowOrValue<object[][]>());
+        public Task<long[]> JsonStrAppendAsync(string key, string value, string path = "$") => CallAsync("JSON.STRAPPEND".InputKey(key, path).Input($"\"{value}\""), rt => rt.ThrowOrValue<long[]>());
+        public Task<long[]> JsonStrLenAsync(string key, string path = "$") => CallAsync("JSON.STRLEN".InputKey(key, path), rt => rt.ThrowOrValue<long[]>());
+        public Task<bool[]> JsonToggleAsync(string key, string path = "$") => CallAsync("JSON.TOGGLE".InputKey(key, path), rt => rt.ThrowOrValue<bool[]>());
+        public Task<string[]> JsonTypeAsync(string key, string path = "$") => CallAsync("JSON.TYPE".InputKey(key, path), rt => rt.ThrowOrValue<string[]>());
+
+        #endregion
+#endif
         public string JsonGet(string key, string indent = default, string newline = default, string space = default, params string[] paths)
             => Call("JSON.GET".InputKey(key)
                 .InputIf(indent != null, "INDENT", indent)


### PR DESCRIPTION
1. ConnectionStringBuilder的Host参数兼容localhost为ipv6的情况;
2. Module模块方法copy同步方法修改来提供异步方法入口;