### PR TITLE
feat(RediSearch): 添加对地理字段和地理形状字段的支持

### DIFF
--- a/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/AggregateBuilder.cs
+++ b/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/AggregateBuilder.cs
@@ -74,7 +74,11 @@ namespace FreeRedis.RediSearch
                 .InputIf(_limitOffset > 0 || _limitNum != 10, "LIMIT", _limitOffset, _limitNum)
                 .InputIf(!string.IsNullOrWhiteSpace(_filter), "FILTER", _filter);
             if (_withCursor) cmd.Input("WITHCURSOR").InputIf(_withCursorCount != -1, "COUNT", _withCursorCount).InputIf(_withCursorMaxIdle != -1, "MAXIDLE", _withCursorMaxIdle);
-            if (_params.Any()) cmd.Input("PARAMS", _params.Count).Input(_params);
+            if (_params.Any())
+            {
+                cmd.Input("PARAMS", _params.Count);
+                _params.ForEach(item => cmd.Input(item));
+            }
             cmd
                .InputIf(_dialect > 0, "DIALECT", _dialect);
             return cmd;
@@ -93,7 +97,7 @@ namespace FreeRedis.RediSearch
         private bool _withCursor;
         private int _withCursorCount = -1;
         private long _withCursorMaxIdle = -1;
-        private List<object> _params = new List<object>();
+        private List<string> _params = new List<string>();
         private int _dialect;
 
         public AggregateBuilder Verbatim(bool value = true)

--- a/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/FtDocumentRepository.cs
+++ b/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/FtDocumentRepository.cs
@@ -72,6 +72,8 @@ namespace FreeRedis.RediSearch
             if (ftattr is FtTextFieldAttribute) return FieldType.Text;
             if (ftattr is FtTagFieldAttribute) return FieldType.Tag;
             if (ftattr is FtNumericFieldAttribute) return FieldType.Numeric;
+            if (ftattr is FtGeoFieldAttribute) return FieldType.Geo;
+            if (ftattr is FtGeoShapeFieldAttribute) return FieldType.GeoShape;
             return FieldType.Text;
         }
 
@@ -130,6 +132,30 @@ namespace FreeRedis.RediSearch
                                 MissingIndex = ftattr.MissingIndex,
                                 NoIndex = ftattr.NoIndex,
                                 Sortable = ftattr.Sortable,
+                            });
+                        }
+                        break;
+                    case FieldType.Geo:
+                        {
+                            var ftattr = field.FieldAttribute as FtGeoFieldAttribute;
+                            createBuilder.AddGeoField(ftattr.Name, new GeoFieldOptions
+                            {
+                                Alias = ftattr.Alias,
+                                MissingIndex = ftattr.MissingIndex,
+                                NoIndex = ftattr.NoIndex,
+                                Sortable = ftattr.Sortable,
+                            });
+
+                        }
+                        break;
+                    case FieldType.GeoShape:
+                        {
+                            var ftattr = field.FieldAttribute as FtGeoShapeFieldAttribute;
+                            createBuilder.AddGeoShapeField(ftattr.Name, new GeoShapeFieldOptions
+                            {
+                                Alias = ftattr.Alias,
+                                System = ftattr.System,
+                                MissingIndex = ftattr.MissingIndex
                             });
                         }
                         break;
@@ -728,6 +754,29 @@ namespace FreeRedis.RediSearch
         public bool MissingIndex { get; set; }
         public FtNumericFieldAttribute() { }
         public FtNumericFieldAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+    [AttributeUsage(AttributeTargets.Property)]
+    public class FtGeoFieldAttribute : FtFieldAttribute
+    {
+        public bool Sortable { get; set; }
+        public bool NoIndex { get; set; }
+        public bool MissingIndex { get; set; }
+        public FtGeoFieldAttribute() { }
+        public FtGeoFieldAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+    [AttributeUsage(AttributeTargets.Property)]
+    public class FtGeoShapeFieldAttribute : FtFieldAttribute
+    {
+        public CoordinateSystem System { get; set; }
+        public bool MissingIndex { get; set; }
+        public FtGeoShapeFieldAttribute() { }
+        public FtGeoShapeFieldAttribute(string name)
         {
             Name = name;
         }

--- a/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/SearchBuilder.cs
+++ b/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/SearchBuilder.cs
@@ -8,7 +8,7 @@ namespace FreeRedis.RediSearch
     {
         public long Total { get; }
         public List<Document> Documents { get; }
-        
+
         public SearchResult(long total, List<Document> docs)
         {
             Total = total;
@@ -111,7 +111,11 @@ namespace FreeRedis.RediSearch
                 .InputIf(!string.IsNullOrWhiteSpace(_payLoad), "PAYLOAD", _payLoad)
                 .InputIf(!string.IsNullOrWhiteSpace(_sortBy), "SORTBY", _sortBy).InputIf(_sortByDesc, "DESC")
                 .InputIf(_limitOffset > 0 || _limitNum != 10, "LIMIT", _limitOffset, _limitNum);
-            if (_params.Any()) cmd.Input("PARAMS", _params.Count).Input(_params);
+            if (_params.Any())
+            {
+                cmd.Input("PARAMS", _params.Count);
+                _params.ForEach(item => cmd.Input(item));
+            }
             cmd
                .InputIf(_dialect > 0, "DIALECT", _dialect);
             return cmd;
@@ -193,7 +197,7 @@ namespace FreeRedis.RediSearch
         internal string _sortBy;
         internal bool _sortByDesc;
         internal long _limitOffset, _limitNum = 10;
-        internal List<object> _params = new List<object>();
+        internal List<string> _params = new List<string>();
         internal int _dialect;
 
         public SearchBuilder NoContent(bool value = true)

--- a/test/Unit/FreeRedis.Tests/RedisClientTests/ModulesTests/RediSearchTests.cs
+++ b/test/Unit/FreeRedis.Tests/RedisClientTests/ModulesTests/RediSearchTests.cs
@@ -10,8 +10,8 @@ namespace FreeRedis.Tests.RedisClientTests.Other
 {
     public class RediSearchTests : TestBase
     {
-		
-		protected static ConnectionStringBuilder Connection = new ConnectionStringBuilder()
+
+        protected static ConnectionStringBuilder Connection = new ConnectionStringBuilder()
         {
             Host = "8.154.26.119:63791",
             MaxPoolSize = 10,
@@ -50,6 +50,12 @@ namespace FreeRedis.Tests.RedisClientTests.Other
 
             [FtNumericField("views")]
             public int Views { get; set; }
+
+            [FtGeoField("location")]
+            public string Location { get; set; }
+
+            [FtGeoShapeField("shape", System = CoordinateSystem.FLAT)]
+            public string Shape { get; set; }
         }
 
         [FtDocument("index_post100", Prefix = "blog:post:")]
@@ -85,9 +91,9 @@ namespace FreeRedis.Tests.RedisClientTests.Other
             catch { }
             repo.CreateIndex();
 
-            repo.Save(new TagMapArrayIndex { Id = 1, Title = "测试标题1 word", Category = "一级分类", Content = "测试内容1suffix", Tags = ["作者1","作者2"], Views = 101 });
-            repo.Save(new TagMapArrayIndex { Id = 2, Title = "prefix测试标题2", Category = "二级分类", Content = "测试infix内容2", Tags = ["作者2","作者3"], Views = 201 });
-            repo.Save(new TagMapArrayIndex { Id = 3, Title = "测试标题3 word", Category = "一级分类", Content = "测试word内容3", Tags = ["作者2","作者5"], Views = 301 });
+            repo.Save(new TagMapArrayIndex { Id = 1, Title = "测试标题1 word", Category = "一级分类", Content = "测试内容1suffix", Tags = ["作者1", "作者2"], Views = 101 });
+            repo.Save(new TagMapArrayIndex { Id = 2, Title = "prefix测试标题2", Category = "二级分类", Content = "测试infix内容2", Tags = ["作者2", "作者3"], Views = 201 });
+            repo.Save(new TagMapArrayIndex { Id = 3, Title = "测试标题3 word", Category = "一级分类", Content = "测试word内容3", Tags = ["作者2", "作者5"], Views = 301 });
 
             repo.Delete(1, 2, 3);
 
@@ -179,9 +185,9 @@ namespace FreeRedis.Tests.RedisClientTests.Other
             repo.Delete(1, 2, 3);
 
             repo.Save(new[]{
-                new TestDoc { Id = 1, Title = "测试标题1 word", Category = "一级分类", Content = "测试内容1suffix", Tags = "作者1,作者2", Views = 101 },
-                new TestDoc { Id = 2, Title = "prefix测试标题2", Category = "二级分类", Content = "测试infix内容2", Tags = "作者2,作者3", Views = 201 },
-                new TestDoc { Id = 3, Title = "测试标题3 word", Category = "一级分类", Content = "测试word内容3", Tags = "作者2,作者5", Views = 301 }
+                new TestDoc { Id = 1, Title = "测试标题1 word", Category = "一级分类", Content = "测试内容1suffix", Tags = "作者1,作者2", Views = 101, Location = "104.800644 38.846127", Shape = "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))" },
+                new TestDoc { Id = 2, Title = "prefix测试标题2", Category = "二级分类", Content = "测试infix内容2", Tags = "作者2,作者3", Views = 201, Location = "-104.991531, 39.742043", Shape = "POLYGON ((2 2.5, 2 3.5, 3.5 3.5, 3.5 2.5, 2 2.5))" },
+                new TestDoc { Id = 3, Title = "测试标题3 word", Category = "一级分类", Content = "测试word内容3", Tags = "作者2,作者5", Views = 301,Location = "-105.0618814,40.5150098", Shape = "POLYGON ((3.5 1, 3.75 2, 4 1, 3.5 1))" }
             });
 
             var list = repo.Search("*").InFields(a => new { a.Title }).ToList();
@@ -235,6 +241,8 @@ namespace FreeRedis.Tests.RedisClientTests.Other
             list = repo.Search("-@views:[200 200]").ToList();
             list = repo.Search("@views==200 | @views==300").Dialect(4).ToList();
             list = repo.Search("*").Filter("views", 200, 300).Dialect(4).ToList();
+            list = repo.Search("@location:[-104.800644 38.846127 100 mi]").ToList();
+            list = repo.Search("@shape:[WITHIN $qshape]").Params("qshape", "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))").Dialect(3).ToList();
         }
 
         [Fact]
@@ -310,8 +318,8 @@ namespace FreeRedis.Tests.RedisClientTests.Other
         }
 
         [Fact]
-		public void FtCreate()
-		{
+        public void FtCreate()
+        {
             cli.FtCreate("idx1")
                 .On(IndexDataType.Hash)
                 .Prefix("blog:post:")


### PR DESCRIPTION
在RediSearch模块中，新增了对地理字段（GeoField）和地理形状字段（GeoShapeField）的支持。同时，更新了相关测试用例以验证新功能。此改动包括：
- 在FtDocumentRepository中添加了对GeoField和GeoShapeField的处理逻辑
- 新增了FtGeoFieldAttribute和FtGeoShapeFieldAttribute属性类
- 更新了测试用例以包含地理字段和地理形状字段的搜索功能
- 修复了Params方法无法正确处理参数的问题