### PR TITLE
feat(RediSearchBuilder): 添加地理和形状查询扩展方法

### DIFF
--- a/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/FtDocumentRepository.cs
+++ b/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/FtDocumentRepository.cs
@@ -470,6 +470,9 @@ namespace FreeRedis.RediSearch
                         case "System.String": callParseResult = ParseCallString(); break;
                         case "System.Math": callParseResult = ParseCallMath(); break;
                         case "System.DateTime": callParseResult = ParseCallDateTime(); break;
+                        case "FreeRedis.RediSearch.SearchBuilderStringExtensions":
+                            callParseResult = ParseCallStringExtension();
+                            break;
                         default: callParseResult = ParseCallOther(); break;
                     }
                     if (!string.IsNullOrEmpty(callParseResult)) return callParseResult;
@@ -517,6 +520,41 @@ namespace FreeRedis.RediSearch
                                     var equalRight = parseExp(callExp.Arguments[0]);
                                     return $"{left}:[{equalRight} {equalRight}]";
                             }
+                        }
+                        return null;
+                    }
+
+                    string ParseCallStringExtension()
+                    {
+                        var left = parseExp(callExp.Arguments[0]);
+                        switch (callExp.Method.Name)
+                        {
+                            case "GeoRadius":
+                                var lon = parseExp(callExp.Arguments[1]);
+                                var lat = parseExp(callExp.Arguments[2]);
+                                var radius = parseExp(callExp.Arguments[3]);
+                                var unit = parseExp(callExp.Arguments[4]);
+                                return $"{left}:[{lon} {lat} {radius} {unit.Replace("'", "")}]";
+                            case "ShapeWithin":
+                                {
+                                    var parameterName = parseExp(callExp.Arguments[1]);
+                                    return $"{left}:[WITHIN ${parameterName.Replace("'", "")}]";
+                                }
+                            case "ShapeContains":
+                                {
+                                    var parameterName = parseExp(callExp.Arguments[1]);
+                                    return $"{left}:[CONTAINS ${parameterName.Replace("'", "")}]";
+                                }
+                            case "ShapeIntersects":
+                                {
+                                    var parameterName = parseExp(callExp.Arguments[1]);
+                                    return $"{left}:[INTERSECTS ${parameterName.Replace("'", "")}]";
+                                }
+                            case "ShapeDisjoint":
+                                {
+                                    var parameterName = parseExp(callExp.Arguments[1]);
+                                    return $"{left}:[DISJOINT ${parameterName.Replace("'", "")}]";
+                                }
                         }
                         return null;
                     }

--- a/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/SearchBuilder.cs
+++ b/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/SearchBuilder.cs
@@ -341,4 +341,14 @@ namespace FreeRedis.RediSearch
             return this;
         }
     }
+
+    public static class SearchBuilderStringExtensions
+    {
+        // 替换为判断field字段是否在以(lon, lat)为圆心，半径为radius的圆内更好，但是只用于Search方法的话还是不用那么复杂的实现了
+        public static bool GeoRadius(this string field, decimal lon, decimal lat, decimal radius, GeoUnit unit) => true;
+        public static bool ShapeWithin(this string field, string parameterName) => true;
+        public static bool ShapeContains(this string field, string parameterName) => true;
+        public static bool ShapeIntersects(this string field, string parameterName) => true;
+        public static bool ShapeDisjoint(this string field, string parameterName) => true;
+    }
 }

--- a/test/Unit/FreeRedis.Tests/RedisClientTests/ModulesTests/RediSearchTests.cs
+++ b/test/Unit/FreeRedis.Tests/RedisClientTests/ModulesTests/RediSearchTests.cs
@@ -242,7 +242,9 @@ namespace FreeRedis.Tests.RedisClientTests.Other
             list = repo.Search("@views==200 | @views==300").Dialect(4).ToList();
             list = repo.Search("*").Filter("views", 200, 300).Dialect(4).ToList();
             list = repo.Search("@location:[-104.800644 38.846127 100 mi]").ToList();
+            list = repo.Search(a => a.Location.GeoRadius(-104.800644m, 38.846127m, 38.846127m, GeoUnit.mi)).ToList();
             list = repo.Search("@shape:[WITHIN $qshape]").Params("qshape", "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))").Dialect(3).ToList();
+            list = repo.Search(a => a.Shape.ShapeWithin("qshape")).Params("qshape", "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))").Dialect(3).ToList();
         }
 
         [Fact]


### PR DESCRIPTION
为SearchBuilder添加GeoRadius、ShapeWithin、ShapeContains、ShapeIntersects和ShapeDisjoint扩展方法，支持地理和形状查询功能。这些方法简化了查询语法，并提供了更直观的API。