### PR TITLE
ClusterAdapter中_hostMappings在遍历添加后又被重新赋值；RefershClusterNodes方法名拼写错误修正

### DIFF
--- a/src/FreeRedis/RedisClient/Adapter/ClusterAdapter.cs
+++ b/src/FreeRedis/RedisClient/Adapter/ClusterAdapter.cs
@@ -33,10 +33,9 @@ namespace FreeRedis
                     foreach (var kv in hostMappings)
                         _hostMappings.Add(kv.Key, kv.Value);
                 }
-                _hostMappings = hostMappings;
                 _baseEncoding = _clusterConnectionStrings.FirstOrDefault()?.Encoding;
                 _ib = new IdleBus<RedisClientPool>(TimeSpan.FromMinutes(10));
-                RefershClusterNodes();
+                RefreshClusterNodes();
             }
 
             bool isdisposed = false;
@@ -281,7 +280,7 @@ namespace FreeRedis
             }
 #endif
 
-            void RefershClusterNodes()
+            void RefreshClusterNodes()
             {
                 Exception clusterException = null;
                 foreach (var testConnection in _clusterConnectionStrings)


### PR DESCRIPTION
ClusterAdapter中_hostMappings在遍历添加后又被重新赋值 修正；
RefershClusterNodes方法名拼写错误修正；
#187 