### PR TITLE
fix(RediSearch):只有非NoIndex字段时才设置权重

### DIFF
--- a/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/CreateBuilder.cs
+++ b/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/CreateBuilder.cs
@@ -203,7 +203,8 @@ namespace FreeRedis.RediSearch
                     _schemaArgs.Add("PHONETIC");
                     _schemaArgs.Add(options.Phonetic);
                 }
-                if (options.Weight != 1.0)
+                // 只有在非NoIndex字段时才设置权重
+                if (!options.NoIndex && options.Weight != 1.0)
                 {
                     _schemaArgs.Add("WEIGHT");
                     _schemaArgs.Add(options.Weight);

--- a/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/FtDocumentRepository.cs
+++ b/src/FreeRedis/RedisClient/Modules/RediSearchBuilder/FtDocumentRepository.cs
@@ -755,7 +755,7 @@ namespace FreeRedis.RediSearch
     [AttributeUsage(AttributeTargets.Property)]
     public class FtTextFieldAttribute : FtFieldAttribute
     {
-        public double Weight { get; set; }
+        public double Weight { get; set; } = 1.0;
         public bool NoStem { get; set; }
         public string Phonetic { get; set; }
         public bool Sortable { get; set; }


### PR DESCRIPTION
目前存在两个问题：
1. 没有设置Weight的情况下，CreateIndex时依然设置了WEIGHT 0
2. 设置了NoIndex的情况下，RediSearch不允许再设置WEIGHT